### PR TITLE
Updated SA0T, SA1J, O48 and LY0B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# keep track of my findings
+ICAO_findings.txt

--- a/CanIFlyTherePretty.json
+++ b/CanIFlyTherePretty.json
@@ -47963,7 +47963,8 @@
       "simIcao":"LY87"
    },
    "LY0B":{
-      "status":"missing"
+      "status":"renamed",
+      "simIcao":"LYBO"
    },
    "LY0C":{
       "status":"renamed",
@@ -54039,7 +54040,8 @@
       "status":"exists"
    },
    "O48":{
-      "status":"missing"
+      "status":"renamed",
+      "simIcao":"KLLR"
    },
    "O50":{
       "status":"missing"
@@ -58942,7 +58944,8 @@
       "status":"missing"
    },
    "SA0T":{
-      "status":"missing"
+      "status":"renamed",
+      "simIcao":"OEL"
    },
    "SA0U":{
       "status":"renamed",
@@ -59004,7 +59007,8 @@
       "simIcao":"SA44"
    },
    "SA1J":{
-      "status":"missing"
+      "status":"renamed",
+      "simIcao":"FRS"
    },
    "SA1K":{
       "status":"renamed",


### PR DESCRIPTION
I've updated 4 ICAOs (SA0T, SA1J, O48 and LY0B) and found 3 more possible solutions, even if they are not an exact match (same geographical position).

Those 3 are located ~10km away of FSE lat/long. but correctly registering in FSE:
FSE      MSFS
===    =====
LSGC   LFIA   10Km away
LFXI     LF64  11Km away
EGNA  EGXO 10Km away

It is up to you if you want to modify those 3 as well (in my opinion it will help).
All these are based on my FSE flights and Aardvark MSFS ICAO tool.