### PR TITLE
Map Q35 to KJTC

### DIFF
--- a/CanIFlyTherePretty.json
+++ b/CanIFlyTherePretty.json
@@ -57553,7 +57553,8 @@
       "simIcao":"KPRZ"
    },
    "Q35":{
-      "status":"missing"
+      "status":"renamed",
+      "simIcao":"KJTC"
    },
    "Q37":{
       "status":"renamed",


### PR DESCRIPTION
Adds only one small mapping. Q35 -> KJTC

Proof:
https://en.wikipedia.org/wiki/Springerville_Municipal_Airport